### PR TITLE
Reorder charts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The CRDs are in a separate chart and managed independently, following the [Helm 
 
 ## Repository Structure
 
-- [charts/kompass-compute](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute): Contains the Helm chart for the main Kompass Compute components.
 - [charts/kompass-compute-crd](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute-crd): Contains the Helm chart for the Custom Resource Definitions (CRDs) required by Kompass Compute.
+- [charts/kompass-compute](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute): Contains the Helm chart for the main Kompass Compute components.
 
 Regarding CRDs: Installing [charts/kompass-compute](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute) will install the CRDs as well, but updating it will not change the CRDs.
 To update the CRDs you should use the [CRDs chart (charts/kompass-compute-crd)](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute-crd).
@@ -18,5 +18,5 @@ To update the CRDs you should use the [CRDs chart (charts/kompass-compute-crd)](
 
 For details about each chart, please refer to their respective README files:
 
-- [charts/kompass-compute](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute)
 - [charts/kompass-compute-crd](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute-crd)
+- [charts/kompass-compute](https://github.com/zesty-co/kompass-compute/tree/main/charts/kompass-compute)


### PR DESCRIPTION
The CRD chart should be installed first so it should appear first in the readme.