### PR TITLE
feat: Add to WorkloadDescriptor status a root cause explanation in ca…

### DIFF
--- a/charts/kompass-compute-crd/Chart.yaml
+++ b/charts/kompass-compute-crd/Chart.yaml
@@ -3,5 +3,5 @@ name: kompass-compute-crd
 description: Zesty Kompass Compute CRD for Kubernetes
 
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.12.6"

--- a/charts/kompass-compute-crd/templates/kompass.zesty.co_workloaddescriptors.yaml
+++ b/charts/kompass-compute-crd/templates/kompass.zesty.co_workloaddescriptors.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.protection.state
       name: State
       type: string
+    - jsonPath: .status.protection.message
+      name: Message
+      type: string
     - jsonPath: .status.protection.lastUpdatedAt
       name: Last_Updated
       type: date

--- a/charts/kompass-compute-crd/templates/qscaler.qubex.ai_qcacherevisioncreations.yaml
+++ b/charts/kompass-compute-crd/templates/qscaler.qubex.ai_qcacherevisioncreations.yaml
@@ -120,25 +120,51 @@ spec:
               imageSizeCalculations:
                 description: Image size calculations results
                 items:
+                  description: |-
+                    ImageSizeCalculation records the result of calculating the size of a container image for a
+                    specific architecture. It captures the outcome status, a human-readable reason on failure, the
+                    content hash, total compressed size in bytes, and a per-layer size breakdown used for cache planning.
                   properties:
                     architecture:
+                      description: Architecture is the CPU architecture (e.g. AMD64,
+                        ARM64) for which the image was inspected.
                       enum:
                       - AMD64
                       - ARM64
                       type: string
+                    details:
+                      default: ""
+                      description: Details provides additional details when Status
+                        is Failed.
+                      type: string
                     hash:
+                      description: Hash is the content-addressable digest of the image
+                        manifest, used to detect image updates.
                       type: string
                     image:
+                      description: Image is the fully-qualified container image reference
+                        that was evaluated.
                       type: string
                     layersHash:
                       additionalProperties:
                         format: int64
                         type: integer
+                      description: LayersHash maps each layer digest to its uncompressed
+                        size in bytes, used for fine-grained cache planning.
                       type: object
+                    reason:
+                      default: ""
+                      description: Reason provides a human-readable explanation when
+                        Status is Failed.
+                      type: string
                     size:
+                      description: Size is the total uncompressed size of the image
+                        in bytes across all layers.
                       format: int64
                       type: integer
                     status:
+                      description: Status reflects whether the size calculation is
+                        still pending, succeeded, or failed.
                       enum:
                       - Pending
                       - Failed

--- a/charts/kompass-compute-crd/templates/qscaler.qubex.ai_qcacheshards.yaml
+++ b/charts/kompass-compute-crd/templates/qscaler.qubex.ai_qcacheshards.yaml
@@ -125,25 +125,51 @@ spec:
               imageSizeCalculations:
                 description: Image size calculations
                 items:
+                  description: |-
+                    ImageSizeCalculation records the result of calculating the size of a container image for a
+                    specific architecture. It captures the outcome status, a human-readable reason on failure, the
+                    content hash, total compressed size in bytes, and a per-layer size breakdown used for cache planning.
                   properties:
                     architecture:
+                      description: Architecture is the CPU architecture (e.g. AMD64,
+                        ARM64) for which the image was inspected.
                       enum:
                       - AMD64
                       - ARM64
                       type: string
+                    details:
+                      default: ""
+                      description: Details provides additional details when Status
+                        is Failed.
+                      type: string
                     hash:
+                      description: Hash is the content-addressable digest of the image
+                        manifest, used to detect image updates.
                       type: string
                     image:
+                      description: Image is the fully-qualified container image reference
+                        that was evaluated.
                       type: string
                     layersHash:
                       additionalProperties:
                         format: int64
                         type: integer
+                      description: LayersHash maps each layer digest to its uncompressed
+                        size in bytes, used for fine-grained cache planning.
                       type: object
+                    reason:
+                      default: ""
+                      description: Reason provides a human-readable explanation when
+                        Status is Failed.
+                      type: string
                     size:
+                      description: Size is the total uncompressed size of the image
+                        in bytes across all layers.
                       format: int64
                       type: integer
                     status:
+                      description: Status reflects whether the size calculation is
+                        still pending, succeeded, or failed.
                       enum:
                       - Pending
                       - Failed

--- a/charts/kompass-compute/Chart.yaml
+++ b/charts/kompass-compute/Chart.yaml
@@ -3,5 +3,5 @@ name: kompass-compute
 description: Zesty Kompass Compute for Kubernetes
 
 type: application
-version: 0.1.25
+version: 0.1.26
 appVersion: "0.13.6"

--- a/charts/kompass-compute/templates/hiberscaler-clusterrole.yaml
+++ b/charts/kompass-compute/templates/hiberscaler-clusterrole.yaml
@@ -44,6 +44,7 @@ rules:
       - "qscaler.qubex.ai"
     resources:
       - "qcacheshards"
+      - "qcacherevisioncreations"
       - "qcachepullmappings"
     verbs:
       - "get"


### PR DESCRIPTION
…ses where one of the images failed to pull

- Extend WorkloadDescriptor CRD to print message next to the state column
- Add `reason` and `description` to ImageSizaCalculatuions in the QCacheRevisionCreations and the QCacheShards